### PR TITLE
Feature/get definition

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -38,7 +38,15 @@ var getCmd = &cobra.Command{
 	Example: `  # List clusters
   ecsher get cluster
   # List services filtering by name
-  esher get service -c CLUSTER_NAME --name SERVICE_NAME`,
+  esher get service -c CLUSTER_NAME --name SERVICE_NAME
+  # List Tasks
+  esher get task -c CLUSTER_NAME
+  # List TaskDefinition families
+  ecsher get definition
+  ecsher get definition --prefix FAMILY_PREFIX
+  # List TaskDefinition revisions in the specified family
+  ecsher get definition --family FAMILY_NAME
+  `,
 }
 
 // GetOptions used in get command

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -187,7 +187,7 @@ func showTaskDefinitionFamilies() {
 	}
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
-	fmt.Fprintln(w, "NAME")
+	fmt.Fprintln(w, "FAMILY")
 	for _, family := range families {
 		fmt.Fprintf(w, "%s\n", family)
 	}
@@ -205,7 +205,7 @@ func showTaskDefinitionRevisions() {
 	}
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, 0, 8, 0, '\t', 0)
-	fmt.Fprintln(w, "NAME \tREVISION")
+	fmt.Fprintln(w, "FAMILY \tREVISION")
 	for _, definition := range definitions {
 		family, revision := util.DivideTaskDefinitionArn(definition)
 		fmt.Fprintf(w, "%s \t%s\n", family, revision)

--- a/ecs/definition.go
+++ b/ecs/definition.go
@@ -1,0 +1,59 @@
+package ecs
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+)
+
+func ListFamily(region string, prefix string, status string) ([]string, error) {
+	client := GetClient(region)
+	input := ecs.ListTaskDefinitionFamiliesInput{}
+	if prefix != "" {
+		input.FamilyPrefix = &prefix
+	}
+
+	if status == "ACTIVE" || status == "INACTIVE" {
+		input.Status = types.TaskDefinitionFamilyStatus(status)
+	} else {
+		input.Status = "ACTIVE"
+	}
+
+	result, err := client.ListTaskDefinitionFamilies(context.TODO(), &input)
+	if err != nil {
+		return []string{}, err
+	}
+	return result.Families, nil
+}
+
+func GetRevisions(region string, family string, status string) ([]string, error) {
+	client := GetClient(region)
+	input := ecs.ListTaskDefinitionsInput{}
+
+	if family != "" {
+		input.FamilyPrefix = &family
+	}
+	if status == "ACTIVE" || status == "INACTIVE" {
+		input.Status = types.TaskDefinitionStatus(status)
+	} else {
+		input.Status = "ACTIVE"
+	}
+
+	result, err := client.ListTaskDefinitions(context.TODO(), &input)
+	if err != nil {
+		return []string{}, err
+	}
+	return result.TaskDefinitionArns, err
+}
+
+func DescribeDefinition(region string, name string) (types.TaskDefinition, error) {
+	client := GetClient(region)
+	definition, err := client.DescribeTaskDefinition(context.TODO(), &ecs.DescribeTaskDefinitionInput{
+		TaskDefinition: &name,
+	})
+	if err != nil {
+		return types.TaskDefinition{}, err
+	}
+	return *definition.TaskDefinition, err
+}

--- a/util/resources.go
+++ b/util/resources.go
@@ -2,22 +2,46 @@ package util
 
 import "strings"
 
+const (
+	TaskDefinitionAlias = "taskdef"
+	ServiceAlias        = "svc"
+)
+
 func LikeCluster(arg string) bool {
 	return strings.Contains(strings.ToLower(arg), "cluster")
 }
 
 func LikeService(arg string) bool {
-	if arg == "svc" {
+	if arg == ServiceAlias {
 		return true
 	}
 	return strings.Contains(strings.ToLower(arg), "service")
 }
 
 func LikeTask(arg string) bool {
+	if arg == TaskDefinitionAlias {
+		return false
+	}
 	return strings.Contains(strings.ToLower(arg), "task")
+}
+
+func LikeDefinition(arg string) bool {
+	if arg == TaskDefinitionAlias {
+		return true
+	}
+	return strings.Contains(strings.ToLower(arg), "definition")
 }
 
 func ArnToName(arn string) string {
 	splited := strings.Split(arn, "/")
 	return splited[len(splited)-1]
+}
+
+func DivideTaskDefinitionArn(taskDefinitionArn string) (string, string) {
+	name := ArnToName(taskDefinitionArn)
+	splited := strings.Split(name, ":")
+	if len(splited) <= 1 {
+		return splited[0], ""
+	}
+	return splited[0], splited[1]
 }

--- a/util/resources_test.go
+++ b/util/resources_test.go
@@ -27,5 +27,17 @@ func TestLikeTask(t *testing.T) {
 		t.Fatal("task is LikeTask")
 	} else if !LikeTask("tasks") {
 		t.Fatal("tasks is LikeTask")
+	} else if LikeTask("taskdef") {
+		t.Fatal("taskdef is not LikeTask")
+	}
+}
+
+func TestLikeDefinition(t *testing.T) {
+	if !LikeDefinition("taskdef") {
+		t.Fatal("taskdef is LikeDefinition")
+	} else if !LikeDefinition("definition") {
+		t.Fatal("definition is LikeDefinition")
+	} else if !LikeDefinition("definitions") {
+		t.Fatal("definitions is LikeDefinition")
 	}
 }


### PR DESCRIPTION
Implements #12 

When we set no options, ecsher shows list of family names.

```
$ ecsher get definition
FAMILY
GofeedLineNotifierInfraStacktaskdef504964F4
hello
nginx-fargate
```

Able to filtering by `--prefix` option.

```
$ ecsher get definition --prefix hello
FAMILY
hello
```

Able to filtering by `--status` option.

```
$ ecsher get definition --status INACTIVE
FAMILY
FargateServiceDiscoveryStackFargateResourcesTaskDefinition5D748E3B
nginx-ec2
```

When we specify `--family` option, ecsher shows list of revisions.

```
$ ecsher get definition --family hello
FAMILY  REVISION
hello   1
```