### PR TITLE
If LogConfiguration is nil, return false

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -152,7 +152,7 @@ func getTaskLogs() {
 		container = taskDefinition.ContainerDefinitions[0]
 	}
 
-	if container.LogConfiguration.LogDriver != "awslogs" {
+	if !util.IsAwslogsLogDriver(container) {
 		fmt.Println("logDriver must be awslogs")
 		os.Exit(1)
 	}

--- a/util/logs.go
+++ b/util/logs.go
@@ -9,6 +9,7 @@ import (
 )
 
 const (
+	Awslogs            = "awslogs"
 	LogGroupKey        = "awslogs-group"
 	LogRegionKey       = "awslogs-region"
 	LogStreamPrefixKey = "awslogs-stream-prefix"
@@ -55,4 +56,11 @@ func AscendingSortTaskLogs(logs []cloudwatchTypes.OutputLogEvent) []cloudwatchTy
 		return *logs[i].Timestamp < *logs[j].Timestamp
 	})
 	return logs
+}
+
+func IsAwslogsLogDriver(containerDefinition types.ContainerDefinition) bool {
+	if containerDefinition.LogConfiguration == nil {
+		return false
+	}
+	return containerDefinition.LogConfiguration.LogDriver == Awslogs
 }

--- a/util/logs_test.go
+++ b/util/logs_test.go
@@ -102,3 +102,46 @@ func TestAscendingTaskLogs(t *testing.T) {
 		}
 	}
 }
+
+func TestIsAwslogsLogDriver(t *testing.T) {
+	cases := []struct {
+		container types.ContainerDefinition
+		expected  bool
+	}{
+		{
+			container: types.ContainerDefinition{
+				LogConfiguration: nil,
+			},
+			expected: false,
+		},
+		{
+			container: types.ContainerDefinition{
+				LogConfiguration: &types.LogConfiguration{},
+			},
+			expected: false,
+		},
+		{
+			container: types.ContainerDefinition{
+				LogConfiguration: &types.LogConfiguration{
+					LogDriver: "json",
+				},
+			},
+			expected: false,
+		},
+		{
+			container: types.ContainerDefinition{
+				LogConfiguration: &types.LogConfiguration{
+					LogDriver: "awslogs",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, c := range cases {
+		actual := IsAwslogsLogDriver(c.container)
+		if actual != c.expected {
+			t.Errorf("expect %v, got %v", c.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Fix #34 

## How

- implements IsAwslogsLogDriver func
- if LogConfiguration is `nil`, this func return `false`